### PR TITLE
 set pixelRatio to use Retina Option for fancybox 2

### DIFF
--- a/static/fancybox2/constants.txt
+++ b/static/fancybox2/constants.txt
@@ -27,6 +27,9 @@ plugin.cljqueryfancybox {
 	
 	# cat=plugin.cl_jqueryfancybox; type=int+; label=maxHeight:Maximum height fancyBox should be allowed to resize to
 	maxHeight = 9999
+
+	# cat=plugin.cl_jqueryfancybox; type=int+; label=pixelRatio:Ratio for retina, set to 2 for retina density 2x 
+	pixelRatio = 1
 	
 	# cat=plugin.cl_jqueryfancybox; type=options[true,false]; label=autoSize:If set to true, for 'inline', 'ajax' and 'html' type content width/height is auto determined. If no dimensions set this may give unexpected results
 	autoSize =true

--- a/static/fancybox2/setup.txt
+++ b/static/fancybox2/setup.txt
@@ -35,6 +35,7 @@ page.jsFooterInline.800 {
 		'minHeight' : {$plugin.cljqueryfancybox.minHeight},
 		'maxWidth' : {$plugin.cljqueryfancybox.maxWidth},
 		'maxHeight' : {$plugin.cljqueryfancybox.maxHeight},
+		'pixelRatio' : {$plugin.cljqueryfancybox.pixelRatio},
 		'autoSize' : {$plugin.cljqueryfancybox.autoSize},
 		'fitToView' : {$plugin.cljqueryfancybox.fitToView},
 		'aspectRatio' : {$plugin.cljqueryfancybox.aspectRatio},


### PR DESCRIPTION
hi Sven

There is a option **pixelRatio** to use fancybox to force retina, here in action:

http://www.teatimeforauniverse.com/about/main/

I did not find a repro for 4.0.1, and still using TYPO3 6.2, this works for me